### PR TITLE
Revert "Bump rollup-plugin-dts from 0.15.1 to 1.1.1 (#4)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4110,9 +4110,9 @@
       }
     },
     "rollup-plugin-dts": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-1.1.1.tgz",
-      "integrity": "sha512-3raNE4UkZwnXPKWhjj24oOBez06ycHjnSthRgeHZWKgiLiB0zc6oL/Q52EKTt3NP1MadzVZe8kqM+9QJKHVNOw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-0.15.1.tgz",
+      "integrity": "sha512-MFO8pMI9GI57sYOIeYUCzQmTZgATEma9616rAaEaTwZxPo9MVC7NkgOMyBrUyjULSoScdYo+3C0+sOq60rL5RQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/jest": "^24.0.13",
     "jest": "^24.8.0",
     "rollup": "^1.15.1",
-    "rollup-plugin-dts": "^1.1.1",
+    "rollup-plugin-dts": "^0.15.1",
     "ts-jest": "^24.0.2",
     "tslib": "^1.10.0",
     "typescript": "^3.5.1",


### PR DESCRIPTION
`rollup-plugin-dts` version 1.0 removes support for transpiling `.ts` to `.js`, but this project still uses that feature. Revert for now, replace with something else later.

Reverts MattiasBuelens/remote-web-streams#4